### PR TITLE
feat: create Contact type and complete changes to db script

### DIFF
--- a/src/extension/background-script/db.ts
+++ b/src/extension/background-script/db.ts
@@ -3,6 +3,7 @@ import browser from "webextension-polyfill";
 import type {
   DbAllowance,
   DbBlocklist,
+  DbContact,
   DbPayment,
   DbPermission,
 } from "~/types";
@@ -12,6 +13,7 @@ class DB extends Dexie {
   payments: Dexie.Table<DbPayment, number>;
   blocklist: Dexie.Table<DbBlocklist, number>;
   permissions: Dexie.Table<DbPermission, number>;
+  contacts: Dexie.Table<DbContact, number>;
 
   constructor() {
     super("LBE");
@@ -28,7 +30,7 @@ class DB extends Dexie {
       permissions: "++id,allowanceId,host,method,enabled,blocked,createdAt",
     });
     this.version(4).stores({
-      contacts: "++id, &lnAddress, accountId",
+      contacts: "++id,&lnAddress,accountId,enabled,createdAt",
       payments:
         "++id,allowanceId,contactId,host,location,name,description,totalAmount,totalFees,preimage,paymentRequest,paymentHash,destination,createdAt",
     });
@@ -37,6 +39,7 @@ class DB extends Dexie {
     this.payments = this.table("payments");
     this.blocklist = this.table("blocklist");
     this.permissions = this.table("permissions");
+    this.contacts = this.table("contacts");
   }
 
   async saveToStorage() {
@@ -44,12 +47,14 @@ class DB extends Dexie {
     const paymentsArray = await this.payments.toArray();
     const blocklistArray = await this.blocklist.toArray();
     const permissionsArray = await this.permissions.toArray();
+    const contactsArray = await this.contacts.toArray();
 
     await browser.storage.local.set({
       allowances: allowanceArray,
       payments: paymentsArray,
       blocklist: blocklistArray,
       permissions: permissionsArray,
+      contacts: contactsArray,
     });
     return true;
   }
@@ -64,7 +69,7 @@ class DB extends Dexie {
     console.info("Loading DB data from storage");
 
     return browser.storage.local
-      .get(["allowances", "payments", "blocklist", "permissions"])
+      .get(["allowances", "payments", "blocklist", "permissions", "contacts"])
       .then((result) => {
         const allowancePromise = this.allowances.count().then((count) => {
           // if the DB already has entries we do not need to add the data from the browser storage. We then already have the data in the indexeddb
@@ -126,12 +131,28 @@ class DB extends Dexie {
           }
         });
 
+        const contactsPromise = this.contacts.count().then((count) => {
+          // if the DB already has entries we do not need to add the data from the browser storage. We then already have the data in the indexeddb
+          if (count > 0) {
+            console.info(`Found ${count} contacts already in the DB`);
+            return;
+          } else if (result.contacts && result.contacts.length > 0) {
+            // adding the data from the browser storage
+            return this.contacts
+              .bulkAdd(result.contacts)
+              .catch(Dexie.BulkError, function (e) {
+                console.error("Failed to add contacts; ignoring", e);
+              });
+          }
+        });
+
         // wait for all allowances and payments to be loaded
         return Promise.all([
           allowancePromise,
           paymentsPromise,
           blocklistPromise,
           permissionsPromise,
+          contactsPromise,
         ]);
       })
       .catch((e) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { PaymentRequestObject } from "bolt11";
-import { CURRENCIES, ACCOUNT_CURRENCIES } from "~/common/constants";
+import { ACCOUNT_CURRENCIES, CURRENCIES } from "~/common/constants";
 import connectors from "~/extension/background-script/connectors";
 import {
   ConnectorInvoice,
@@ -513,6 +513,7 @@ export type Transaction = {
 
 export interface DbPayment {
   allowanceId: string;
+  contactId?: string;
   createdAt: string;
   description: string;
   destination: string;
@@ -611,6 +612,18 @@ export interface Allowance extends Omit<DbAllowance, "id"> {
   paymentsCount: number;
   percentage: string;
   usedBudget: number;
+}
+
+export interface DbContact {
+  accountId: string;
+  createdAt: string;
+  enabled: boolean;
+  id: number;
+  lnAddress: string;
+}
+
+export interface Contact extends Omit<DbContact, "id"> {
+  id: number;
 }
 
 export interface SettingsStorage {


### PR DESCRIPTION
### Describe the changes you have made in this PR

1. Adding `DbContact` and `Contact` types
2. Adding `enabled` and `createdAt` to contact schema. All the other schemas have createdAt so I figured it's appropriate. As for enabled, my thinking was similar to `Allowance`. From what I gather, an allowance is created on the backend when a payment is made to an address with a host / website. But it's up to the user to enable / disable the Allowance for it be shown on the UI. Similarly, I imagine we can create a contact db entry for every payment made to an LN address, but only show the user the "Contact" for that address if they enable it.
3. Complete the db script for contacts

### Link this PR to an issue

https://github.com/getAlby/lightning-browser-extension/issues/1965

### Type of change

- `feat`: New feature (non-breaking change which adds functionality)

### Checklist

- [x] My code follows the style guidelines of this project and performed a self-review of my own code
- [ ] New and existing tests pass locally with my changes
            - one e2e test failed, looks like a React issue however
- [x] I checked if I need to make corresponding changes to the documentation (and made those changes if needed)
